### PR TITLE
fix: stop frontend requesting localhost in production

### DIFF
--- a/src/app/core/services/base/base.ts
+++ b/src/app/core/services/base/base.ts
@@ -1,8 +1,7 @@
 import {inject, Injectable} from '@angular/core';
 import {HttpClient} from "@angular/common/http";
-import {environment} from "@environments/environment.development";
-import {catchError, delay, map, Observable, throwError} from "rxjs";
-import {response} from "express";
+import {environment} from "@environments/environment";
+import {catchError, map, Observable, throwError} from "rxjs";
 
 @Injectable({
   providedIn: 'root'


### PR DESCRIPTION
## Summary

- `base.ts` was importing directly from `environment.development` instead of `environment`, which hardcodes `localhost` URLs and bypasses Angular's build-time file replacement mechanism entirely
- Changed the import to `environment` so the production build correctly resolves to `https://api.artafera.ch`
- Also removed a stray unused `import {response} from "express"` that snuck in

## Root cause

Angular replaces `environment.ts` with `environment.development.ts` during dev builds via `fileReplacements` in `angular.json`. But if you import `environment.development` directly by name, that replacement never fires — the dev file is always loaded, even in production.

## Test plan

- [ ] Build for production (`ng build`) and verify network requests go to `https://api.artafera.ch` instead of `http://localhost:8080`
- [ ] Confirm dev server still works as expected (`ng serve`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVyD1krsunjom2CKx33UFi)_